### PR TITLE
fix(ci): update script logic to handle direct zip download

### DIFF
--- a/scripts/get_upstream_docs.py
+++ b/scripts/get_upstream_docs.py
@@ -5,14 +5,15 @@ import requests
 
 # Temporarily use main to generate docs, switch to latest release after next release
 api_url = "https://github.com/runfinch/finch/archive/refs/heads/main.zip"
+# Releases require making two requests, whereas the main.zip link is a direct download
 # api_url = "https://api.github.com/repos/runfinch/finch/releases/latest"
+# response = requests.get(api_url)
+# data = response.json()
+# zip_file_url = data['zipball_url']
+# r = requests.get(zip_file_url)
 
-response = requests.get(api_url)
-data = response.json()
+r = requests.get(api_url)
 
-zip_file_url = data['zipball_url']
-
-r = requests.get(zip_file_url)
 z = zipfile.ZipFile(io.BytesIO(r.content))
 namelist = z.namelist()
 


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
- Fixes https://github.com/runfinch/finch-website/actions/runs/6629874329/job/18010100747. The original logic assumes making two requests, whereas the latest zip archive can be downloaded directly. We'll switch back after the next release comes out.


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
