### PR TITLE
ci: Remove temporary docs url

### DIFF
--- a/scripts/get_upstream_docs.py
+++ b/scripts/get_upstream_docs.py
@@ -3,16 +3,12 @@ import zipfile
 
 import requests
 
-# Temporarily use main to generate docs, switch to latest release after next release
-api_url = "https://github.com/runfinch/finch/archive/refs/heads/main.zip"
 # Releases require making two requests, whereas the main.zip link is a direct download
-# api_url = "https://api.github.com/repos/runfinch/finch/releases/latest"
-# response = requests.get(api_url)
-# data = response.json()
-# zip_file_url = data['zipball_url']
-# r = requests.get(zip_file_url)
-
-r = requests.get(api_url)
+api_url = "https://api.github.com/repos/runfinch/finch/releases/latest"
+response = requests.get(api_url)
+data = response.json()
+zip_file_url = data['zipball_url']
+r = requests.get(zip_file_url)
 
 z = zipfile.ZipFile(io.BytesIO(r.content))
 namelist = z.namelist()


### PR DESCRIPTION
**Issue number:** 

Closes # https://github.com/runfinch/finch-website/issues/38

**Description of changes:**
Now that Finch 1.0 is released, we can move the CI back to pulling from releases.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
