### PR TITLE
docs: Use preferred naming convention for compose files

### DIFF
--- a/docs/docs/container-images/signing-images.md
+++ b/docs/docs/container-images/signing-images.md
@@ -188,7 +188,7 @@ cd finch/contrib/hello-finch
 
     === "macOS / bash"
         ```bash
-        cat <<EOF > docker-compose.yml
+        cat <<EOF > compose.yaml
         services:
           hello-finch:
             image: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
@@ -206,7 +206,7 @@ cd finch/contrib/hello-finch
             build: .
             x-nerdctl-sign: cosign
             x-nerdctl-cosign-private-key: cosign.key
-        "@ > docker-compose.yml
+        "@ > compose.yaml
         ```
 
 2. Build the container image `finch compose build`
@@ -246,7 +246,7 @@ cd finch/contrib/hello-finch
 
     === "macOS / bash"
         ```bash
-        cat <<EOF > docker-compose.yml
+        cat <<EOF > compose.yaml
         services:
           hello-finch:
             image: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
@@ -268,7 +268,7 @@ cd finch/contrib/hello-finch
             x-nerdctl-cosign-private-key: cosign.key
             x-nerdctl-verify: cosign
             x-nerdctl-cosign-public-key: cosign.pub
-        "@ > docker-compose.yml
+        "@ > compose.yaml
         ```
 
 2. The image signatures can be verified when pulling the container images.

--- a/docs/docs/getting-started/compose.md
+++ b/docs/docs/getting-started/compose.md
@@ -4,8 +4,8 @@ Containerized applications composed of multiple services are often defined in
 [Docker Compose
 files](https://compose-spec.io/). Finch
 offers a CLI that is compatible to the
-[docker-compose](https://github.com/docker/compose) cli, therefore commands that
-you have used previously like `docker-compose up` could be translated to `finch
+[docker compose](https://github.com/docker/compose) cli, therefore commands that
+you have used previously like `docker compose up` could be translated to `finch
 compose up`.
 
 ## Building Containers Images with a Compose File
@@ -26,8 +26,8 @@ set as local context to use.
         git clone https://github.com/runfinch/finch.git
         cd finch/contrib/hello-finch
 
-        # Add a Docker Compose File to the Directory
-        cat <<EOF > docker-compose.yml
+        # Add a Compose File to the Directory
+        cat <<EOF > compose.yaml
         services:
           hello-finch:
             image: hello-finch
@@ -39,13 +39,13 @@ set as local context to use.
         git clone https://github.com/runfinch/finch.git
         cd finch/contrib/hello-finch
 
-        # Add a Docker Compose File to the Directory
+        # Add a Compose File to the Directory
         @"
         services:
           hello-finch:
             image: hello-finch
             build: .
-        "@ > docker-compose.yml
+        "@ > compose.yaml
         ```
 
 2. Build the container images using `finch compose build`.
@@ -75,7 +75,7 @@ be started with the `finch compose up` command.
 
 1. Leveraging the
    [hello-finch](https://github.com/runfinch/finch/tree/main/contrib/hello-finch)
-   sample application, we can create a Docker Compose file. In the file we
+   sample application, we can create a Compose file. In the file we
    define the `hello-finch` service and provide a context for the container
    image build.
 
@@ -84,8 +84,8 @@ be started with the `finch compose up` command.
         git clone https://github.com/runfinch/finch.git
         cd finch/contrib/hello-finch
 
-        # Add a Docker Compose File to the Directory
-        cat <<EOF > docker-compose.yml
+        # Add a Compose File to the Directory
+        cat <<EOF > compose.yaml
         services:
           hello-finch:
             image: hello-finch
@@ -97,13 +97,13 @@ be started with the `finch compose up` command.
         git clone https://github.com/runfinch/finch.git
         cd finch/contrib/hello-finch
 
-        # Add a Docker Compose File to the Directory
+        # Add a Compose File to the Directory
         @"
         services:
           hello-finch:
             image: hello-finch
             build: .
-        "@ > docker-compose.yml
+        "@ > compose.yaml
         ```
 
 2. Next we will run the service with `finch compose up`, if the container image


### PR DESCRIPTION
**Issue number:** N/A

Closes #N/A

Per the compose spec (linked [here](https://docs.docker.com/compose/compose-application-model/#the-compose-file) and [here](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file)), the preferred naming convention for a compose file is `compose.yaml`.

References to `docker-compose` typically refers to Compose v1 which is deprecated and should be removed. This change highlights that Finch is Compose v2 compatible.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.