### PR TITLE
docs: Add sonoma to the macos installation docs

### DIFF
--- a/docs/docs/managing-finch/macos/installation.md
+++ b/docs/docs/managing-finch/macos/installation.md
@@ -6,9 +6,9 @@ To get started with Finch on macOS, the development machine must meet the
 following prerequisites.
 
 * macOS versions:
+    * 14 Sonoma
     * 13 Ventura
     * 12 Monterey
-    * 11 Big Sur (known to work, but not tested)
 * Both Intel and Apple Silicon based systems running the last 2 major versions of macOS are supported.
 * Recommended minimum hardware requirements is at least 2 vCPU and 4 GB memory.
 * Administrative privileges are required to install Finch on to the machine.


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
macOS Sonoma was official supported back in November, so I'm updating the docs to reflect that:
https://github.com/runfinch/finch/issues/680

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
