### PR TITLE
ci: pin mkdocs-deploy-gh-pages package to d77dd03

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@d77dd03172e96abbcdb081d8c948224762033653
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_DOMAIN: runfinch.com


### PR DESCRIPTION
**Issue number:**
The mkdocs-deploy-gh-pages package is currently floating by pointing to the tip of maintain. As a finch-website maintainer, the result is loss in build reproducibility.

**Description of changes:**
This change pins mkdocs-deploy-gh-pages GitHub Action package to d77dd03172e96abbcdb081d8c948224762033653.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
