### PR TITLE
docs: default vm type is vz

### DIFF
--- a/docs/docs/configuration-reference.md
+++ b/docs/docs/configuration-reference.md
@@ -64,7 +64,7 @@ Many of Finch's configuration options are currently macOS only, and this will be
         - [QEMU](https://www.qemu.org/) (`qemu`) or Apple [Virtualization
           Framework](https://developer.apple.com/documentation/virtualization) (`vz`).
           Apple Virtualization Framework can only be used on macOS 13 or later. Default
-          is `qemu`
+          is `vz`
     - Windows
         - The only supported vmType for Windows is `wsl2`
 


### PR DESCRIPTION
**Issue number:**

Closes #90

**Description of changes:**
This change updates the websites configuration reference page to document virtualization framework as the default.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
