### PR TITLE
docs: add sudo to the linux docs

### DIFF
--- a/docs/docs/container-images/authentication.md
+++ b/docs/docs/container-images/authentication.md
@@ -7,6 +7,8 @@ the image registry you are using, you either authenticate yourself through the
 helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helpers),
 to manage authentication tokens on your behalf.
 
+### macOS and Windows
+
 === "Amazon ECR"
 
     #### Using the Amazon ECR Credential Helper to login to Amazon ECR
@@ -152,6 +154,125 @@ to manage authentication tokens on your behalf.
 
     ```bash
     finch login
+    Enter Username: username
+    Enter Password:
+    ```
+
+    If the login has been successful, you should see:
+
+    ```bash
+    Login Succeeded
+    ```
+
+### Linux
+
+=== "Amazon ECR"
+
+    #### Using the Amazon ECR Credential Helper to login to Amazon ECR
+
+    The Amazon ECR Credential Helper is a credential helper that handles
+    [Amazon ECR](https://aws.amazon.com/ecr/) authentication tokens for you. It
+    does this by leveraging the AWS credentials used by the the AWS CLI, typically
+    these are located on the workstation at `~/.aws/credentials`. Since Finch requires
+    being run as root, this may be `/root/.aws/credentials`.
+
+    To configure the Amazon ECR credential helper:
+
+    1. Ensure the [AWS
+       credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+       have been configured and are working correctly on the host local machine
+       before attempting to using the Amazon ECR credential helper.
+
+        ```bash
+        aws sts get-caller-identity
+        ```
+
+    2. Install the ecr credential helper by following [these steps](./../../managing-finch/linux/optional-components/#ecr-credential-helper).
+    
+
+    3. If it does not already exist, add `ecr-login` to the registry credentials
+       file located at `/root/.docker/config.json`
+
+        ```bash
+        {
+        	"credsStore": "ecr-login"
+        }
+        ```
+
+    #### Using the AWS CLI to login to Amazon ECR
+
+    Alternatively you can use the AWS CLI to retrieve an
+    [Amazon ECR](https://aws.amazon.com/ecr/) authentication token and pass this
+    into Finch with the `finch login` command. By default this token expires after
+    12 hours.
+
+    ```bash
+    export AWS_ACCOUNT_ID=111222333444
+    export AWS_REGION=eu-west-1
+
+    aws ecr get-login-password --region $AWS_REGION | sudo -E finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+    ```
+
+    If the login has been successful, you should see:
+
+    ```bash
+    Login Succeeded
+    ```
+
+=== "Amazon ECR Public"
+
+    #### Using the Amazon ECR Credential Helper to login to Amazon ECR Public
+
+    The Amazon ECR Credential Helper is a credential helper that handles [Amazon ECR Public](https://gallery.ecr.aws/) authentication tokens for you. It does
+    this by leveraging the AWS credentials used by the the AWS CLI, typically these are located on the workstation at `~/.aws/credentials`.
+
+    To configure the Amazon ECR credential helper:
+
+    1. Ensure the [AWS
+       credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+       have been configured and are working correctly on the host local machine
+       before attempting to using the Amazon ECR credential helper.
+
+        ```bash
+        aws sts get-caller-identity
+        ```
+
+    2. Install the ecr credential helper by following [these steps](./../../managing-finch/linux/optional-components#ecr-credential-helper).
+
+    3. If it does not already exist, add `ecr-login` to the registry credentials
+       file located at `/root/.docker/config.json`
+
+        ```bash
+        {
+        	"credsStore": "ecr-login"
+        }
+        ```
+
+    #### Using the AWS CLI to login to Amazon ECR Public
+
+    Alternatively you can use the AWS CLI to retrieve an [Amazon ECR Public]
+    (https://gallery.ecr.aws/) authentication token and pass this into
+    Finch with the `finch login` command. By default this token expires after 12
+    hours.
+
+    ```bash
+    # Note that the region will always be us-east-1 when authenticating to ECR Public.
+    aws ecr-public get-login-password --region us-east-1 | sudo finch login --username AWS --password-stdin public.ecr.aws
+    ```
+
+    If the login has been successful, you should see:
+
+    ```bash
+    Login Succeeded
+    ```
+
+=== "Docker Hub"
+    To login to [Docker Hub](https://hub.docker.com/), or any registry with
+    username and password authentication. You can use the finch login command
+    and enter the username and password when prompted.
+
+    ```bash
+    sudo finch login
     Enter Username: username
     Enter Password:
     ```

--- a/docs/docs/container-images/lazy-loading.md
+++ b/docs/docs/container-images/lazy-loading.md
@@ -13,22 +13,47 @@ supported.
 
 ## Enable the SOCI Snapshotter
 
-To enable the SOCI snapshotter, you need to edit the [Finch configuration
-file](../configuration-reference/) and add the SOCI snapshotter. The Finch
-configuration file is typically located at `~/.finch/finch.yaml`
+First, we must make sure the SOCI snapshotter is enabled and configured.
 
-```bash
-snapshotters:
-    - soci
-```
+=== "macOS"
+    To enable the SOCI snapshotter, you need to edit the [Finch configuration
+    file](../configuration-reference/) and add the SOCI snapshotter. The Finch
+    configuration file is typically located at `~/.finch/finch.yaml`
 
-After adding SOCI to the Finch configuration file you need to start and stop the
-Finch virtual machine.
+    ```bash
+    snapshotters:
+        - soci
+    ```
 
-```bash
-finch vm stop
-finch vm start
-```
+    After adding SOCI to the Finch configuration file you need to start and stop the
+    Finch virtual machine.
+
+    ```bash
+    finch vm stop
+    finch vm start
+    ```
+
+=== "Windows"
+    To enable the SOCI snapshotter, you need to edit the [Finch configuration
+    file](../configuration-reference/) and add the SOCI snapshotter. The Finch
+    configuration file is typically located at `%LocalAppData%\.finch\finch.yaml`
+
+    ```bash
+    snapshotters:
+        - soci
+    ```
+
+    After adding SOCI to the Finch configuration file you need to start and stop the
+    Finch virtual machine.
+
+    ```bash
+    finch vm stop
+    finch vm start
+    ```
+=== "Linux"
+    Refer to the [Linux Optional Components page](./../managing-finch/linux/optional-components.md#soci-snapshotter) to setup SOCI on Linux.
+
+
 
 ## Generate SOCI Indexes
 
@@ -63,6 +88,15 @@ use the `finch push --snapshotter soci` command.
     finch push --snapshotter soci `
         "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/myimage:latest"
     ```
+=== "Linux"
+    ```bash
+    AWS_ACCOUNT_ID=111222333444
+    AWS_REGION=eu-west-1
+
+    sudo -E finch push --snapshotter soci \
+        $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/myimage:latest
+    ```
+
 
 In the output, you will see that Finch first pushes the container image up to the
 container registry.
@@ -117,6 +151,14 @@ To run the container, you need to pass `--snapshotter soci` into the `finch run`
 
     finch run --snapshotter soci `
         "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/myimage:latest"
+    ```
+=== "Linux"
+    ```bash
+    AWS_ACCOUNT_ID=111222333444
+    AWS_REGION=eu-west-1
+
+    sudo -E finch run --snapshotter soci \
+        $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/myimage:latest
     ```
 
 **Successful Lazy Loading**

--- a/docs/docs/container-images/signing-images.md
+++ b/docs/docs/container-images/signing-images.md
@@ -41,9 +41,18 @@ generate a new key:
    new image that has just been built by `finch build`. In this walkthrough we
    will pull down an existing image.
 
-    ```bash
-    finch pull public.ecr.aws/finch/hello-finch:latest
-    ```
+    === "macOS / bash"
+        ```bash
+        finch pull public.ecr.aws/finch/hello-finch:latest
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch pull public.ecr.aws/finch/hello-finch:latest
+        ```
+    === "Linux"
+        ```bash
+        sudo finch pull public.ecr.aws/finch/hello-finch:latest
+        ```
 
 2. A container image is signed with Finch when it is pushed to a container
    registry, therefore in preparation for the `finch push` we need to re tag the
@@ -70,6 +79,15 @@ generate a new key:
             public.ecr.aws/finch/hello-finch:latest `
             "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch"
         ```
+    === "Linux"
+        ```bash
+        AWS_ACCOUNT_ID=111222333444
+        AWS_REGION=eu-west-1
+
+        sudo finch -E tag \
+            public.ecr.aws/finch/hello-finch:latest \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
+        ```
 
 3. Push and sign the container image with the `finch push --sign cosign`
    command.
@@ -88,6 +106,13 @@ generate a new key:
             --cosign-key cosign.key `
             "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch"
         ```
+    === "Linux"
+        ```bash
+        sudo finch -E push \
+            --sign=cosign  \
+            --cosign-key cosign.key \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
+        ```
 
 4. Verify the Container Image and the Signature with the `cosign verify` command.
 
@@ -102,6 +127,12 @@ generate a new key:
         cosign verify `
             --key cosign.pub `
             "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch"
+        ```
+    === "Linux"
+        ```bash
+        cosign verify \
+            --key cosign.pub \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
         ```
 
 ## Verify a Container Image Signature with cosign
@@ -136,6 +167,16 @@ directory.
         --cosign-key cosign.pub `
         "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch"
     ```
+=== "Linux"
+    ```bash
+    AWS_ACCOUNT_ID=111222333444
+    AWS_REGION=eu-west-1
+
+    sudo -E finch pull \
+        --verify=cosign  \
+        --cosign-key cosign.pub \
+        $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
+    ```
 
 ### Running a Container Image
 
@@ -163,6 +204,16 @@ directory.
         --verify=cosign  `
         --cosign-key cosign.pub `
         "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch"
+    ```
+=== "Linux"
+    ```bash
+    AWS_ACCOUNT_ID=111222333444
+    AWS_REGION=eu-west-1
+
+    sudo -E finch run --rm \
+        --verify=cosign  \
+        --cosign-key cosign.pub \
+        $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
     ```
 
 ## Container Image Signing with Compose and cosign
@@ -208,6 +259,17 @@ cd finch/contrib/hello-finch
             x-nerdctl-cosign-private-key: cosign.key
         "@ > compose.yaml
         ```
+    === "Linux"
+        ```bash
+        cat <<EOF > compose.yaml
+        services:
+          hello-finch:
+            image: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
+            build: .
+            x-nerdctl-sign: cosign
+            x-nerdctl-cosign-private-key: cosign.key
+        EOF
+        ```
 
 2. Build the container image `finch compose build`
 
@@ -237,6 +299,12 @@ cd finch/contrib/hello-finch
         cosign verify `
             --key cosign.pub `
             "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch"
+        ```
+    === "Linux"
+        ```bash
+        cosign verify \
+            --key cosign.pub \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
         ```
 
 ### Verify a container image with compose
@@ -270,15 +338,46 @@ cd finch/contrib/hello-finch
             x-nerdctl-cosign-public-key: cosign.pub
         "@ > compose.yaml
         ```
+    === "Linux"
+        ```bash
+        cat <<EOF > compose.yaml
+        services:
+          hello-finch:
+            image: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch
+            build: .
+            x-nerdctl-sign: cosign
+            x-nerdctl-cosign-private-key: cosign.key
+            x-nerdctl-verify: cosign
+            x-nerdctl-cosign-public-key: cosign.pub
+        EOF
+        ```
 
 2. The image signatures can be verified when pulling the container images.
 
-    ```bash
-    finch compose pull
-    ```
+    === "macOS / bash"
+        ```bash
+        finch compose pull
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch compose pull
+        ```
+    === "Linux"
+        ```bash
+        sudo finch compose pull
+        ```
 
 3. Signatures can also be verified when running the containers.
 
-    ```bash
-    finch compose run
-    ```
+    === "macOS / bash"
+        ```bash
+        finch compose run
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch compose run
+        ```
+    === "Linux"
+        ```bash
+        sudo finch compose run
+        ```

--- a/docs/docs/getting-started/building-images.md
+++ b/docs/docs/getting-started/building-images.md
@@ -33,16 +33,34 @@ this guide we will clone this Finch repository, and build
    with the `finch build`. Here we specifying the tag that we want to use for
    the image, as well as where the build context can be found.
 
-    ```bash
-    finch build --tag hello-finch .
-    ```
+    === "macOS / bash"
+        ```bash
+        finch build --tag hello-finch .
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch build --tag hello-finch .
+        ```
+    === "Linux"
+        ```bash
+        sudo finch build --tag hello-finch .
+        ```
 
 4. You can see the newly build container image in the image store using the
    `finch image list` command.
 
-    ```bash
-    finch image list
-    ```
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch image list
+        ```
 
     The output shows your new container image, the platform it was built for and
     the uncompressed size.
@@ -97,13 +115,29 @@ then you can use the `--platform` flag with `finch build`.
           --tag hello-finch `
           .
         ```
+    === "Linux"
+        ```bash
+        sudo finch build \
+          --platform linux/arm64,linux/amd64 \
+          --tag hello-finch \
+          .
+        ```
 
 4. You can see both container images in the local image store, with the `finch
    image list` command.
 
-    ```bash
-    finch image list
-    ```
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch image list
+        ```
 
     Notice how there are 2 images, one for each architecture.
 

--- a/docs/docs/getting-started/compose.md
+++ b/docs/docs/getting-started/compose.md
@@ -47,19 +47,51 @@ set as local context to use.
             build: .
         "@ > compose.yaml
         ```
+    === "Linux"
+        ```bash
+        git clone https://github.com/runfinch/finch.git
+        cd finch/contrib/hello-finch
+
+        # Add a Compose File to the Directory
+        cat <<EOF > compose.yaml
+        services:
+          hello-finch:
+            image: hello-finch
+            build: .
+        EOF
+        ```
+
 
 2. Build the container images using `finch compose build`.
 
-    ```bash
-    finch compose build
-    ```
+    === "macOS / bash"
+        ```bash
+        finch compose build
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch compose build
+        ```
+    === "Linux"
+        ```bash
+        sudo finch compose build
+        ```
 
 3. You can verify that the container image has been built successfully using the
    `finch image list` command.
 
-    ```bash
-    finch image list
-    ```
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch image list
+        ```
 
     The output should show the container image tagged with the service name.
 
@@ -105,13 +137,41 @@ be started with the `finch compose up` command.
             build: .
         "@ > compose.yaml
         ```
+    === "Linux"
+        ```bash
+        git clone https://github.com/runfinch/finch.git
+        cd finch/contrib/hello-finch
+
+        # Add a Compose File to the Directory
+        cat <<EOF > compose.yaml
+        services:
+          hello-finch:
+            image: hello-finch
+            build: .
+        EOF
+        ```
+
 
 2. Next we will run the service with `finch compose up`, if the container image
    does not exist locally, finch will build the container image before starting
    the service.
 
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch compose up
+        ```
+
+    Upon success, the output should look something like the following:
+
     ```bash
-    finch compose up
     INFO[0018] Creating container hello-finch_hello-finch_1
     INFO[0018] Attaching to logs
     hello-finch_1 |

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -23,17 +23,18 @@ with the following steps.
 2. Verify that everything is working correctly by attempting to run the Finch
    demonstration container image `hello-finch`.
 
-   === "macOS/Windows"
-
-    ```shell
-    $ finch run public.ecr.aws/finch/hello-finch:latest
-    ```
-
+    === "macOS"
+        ```shell
+        $ finch run public.ecr.aws/finch/hello-finch:latest
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        $ finch run public.ecr.aws/finch/hello-finch:latest
+        ```
     === "Linux"
-
-    ```shell
-    $ sudo finch run public.ecr.aws/finch/hello-finch:latest
-    ```
+        ```shell
+        $ sudo finch run public.ecr.aws/finch/hello-finch:latest
+        ```
 
     If everything is ok, you should now see the output:
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -17,14 +17,22 @@ with the following steps.
    once again require the users password.
 
     ```bash
-    finch vm init
+    $ finch vm init
     ```
 
 2. Verify that everything is working correctly by attempting to run the Finch
    demonstration container image `hello-finch`.
 
-    ```bash
-    finch run public.ecr.aws/finch/hello-finch:latest
+   === "macOS/Windows"
+
+    ```shell
+    $ finch run public.ecr.aws/finch/hello-finch:latest
+    ```
+
+    === "Linux"
+
+    ```shell
+    $ sudo finch run public.ecr.aws/finch/hello-finch:latest
     ```
 
     If everything is ok, you should now see the output:

--- a/docs/docs/getting-started/pushing-images.md
+++ b/docs/docs/getting-started/pushing-images.md
@@ -13,9 +13,18 @@ different.
 1. Before pushing a container image, ensure the container image exists in the
    local image store.
 
-    ```bash
-    $ finch image list
-    ```
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch image list
+        ```
 
     In the output you should see a list of all of the container images stored in
     the local container store.
@@ -37,8 +46,8 @@ different.
         export AWS_REGION=eu-west-1
 
         finch tag \
-        hello-finch:latest \
-        $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+            hello-finch:latest \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
         ```
     === "Windows / PowerShell"
         ```powershell
@@ -46,8 +55,17 @@ different.
         $AWS_REGION="eu-west-1"
 
         finch tag `
-        hello-finch:latest `
-        $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+            hello-finch:latest `
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+        ```
+    === "Linux"
+        ```bash
+        export AWS_ACCOUNT_ID=111222333444
+        export AWS_REGION=eu-west-1
+
+        sudo -E finch tag \
+            hello-finch:latest \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
         ```
 
 3. The Amazon ECR registry requires an authentication token to push and pull
@@ -55,9 +73,18 @@ different.
    different for your container image registry, see [registry
    authentication](../../container-images/authentication/) for more information.
 
-    ```bash
-    aws ecr get-login-password --region $AWS_REGION | finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
-    ```
+    === "macOS / bash"
+        ```bash
+        aws ecr get-login-password --region $AWS_REGION | finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        aws ecr get-login-password --region $AWS_REGION | finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+        ```
+    === "Linux"
+        ```bash
+        aws ecr get-login-password --region $AWS_REGION | sudo -E finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+        ```
 
     If the login has been successful you should see:
 
@@ -68,9 +95,18 @@ different.
 4. Using the `finch push` command we push the container image from the local
    machine up to the container image repository.
 
-    ```bash
-    finch push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
-    ```
+    === "macOS / bash"
+        ```bash
+        finch push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+        ```
+    === "Linux"
+        ```bash
+        sudo -E finch push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+        ```
 
 4. With the AWS Console or the AWS CLI we can verify that the container image
    has been successfully pushed.
@@ -100,8 +136,23 @@ to the container registry.
 1. Ensure both architectures of the container image have been built and exist
    locally.
 
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch image list
+        ```
+
+    In the output you should see a list of all of the container images stored in
+    the local container store.
+
     ```bash
-    finch image list
     REPOSITORY     TAG       IMAGE ID        CREATED          PLATFORM       SIZE       BLOB SIZE
     hello-finch    latest    5874669344b3    3 seconds ago    linux/arm64    1.8 MiB    1009.0 KiB
     hello-finch    latest    5874669344b3    3 seconds ago    linux/amd64    0.0 B      1.0 MiB
@@ -129,13 +180,31 @@ to the container registry.
             hello-finch:latest `
             "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest"
         ```
+    === "Linux"
+        ```bash
+        export AWS_ACCOUNT_ID=111222333444
+        export AWS_REGION=eu-west-1
+
+        sudo -E finch tag \
+            hello-finch:latest \
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+        ```
 
     You can verify both images have been re tagged using the `finch image list`
     command.
 
-    ```bash
-    finch image list
-    ```
+    === "macOS / bash"
+        ```bash
+        finch image list
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        finch image list
+        ```
+    === "Linux"
+        ```bash
+        sudo finch image list
+        ```
 
     Now you should see four images, one for each architecture for each tag.
 
@@ -152,9 +221,18 @@ to the container registry.
    different for your container image registry, see [Registry
    Authentication](../../container-images/authentication/) for more information.
 
-    ```bash
-    aws ecr get-login-password --region $AWS_REGION | finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
-    ```
+    === "macOS / bash"
+        ```bash
+        aws ecr get-login-password --region $AWS_REGION | finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+        ```
+    === "Windows / PowerShell"
+        ```powershell
+        aws ecr get-login-password --region $AWS_REGION | finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+        ```
+    === "Linux"
+        ```bash
+        aws ecr get-login-password --region $AWS_REGION | sudo -E finch login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+        ```
 
     If the login has been successful you should see:
 
@@ -175,6 +253,12 @@ to the container registry.
         ```powershell
         finch push `
             --platform linux/arm64,linux/amd64 `
+            $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
+        ```
+    === "Linux"
+        ```bash
+        sudo -E finch push \
+            --platform linux/arm64,linux/amd64 \
             $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/hello-finch:latest
         ```
 

--- a/docs/docs/getting-started/running-containers.md
+++ b/docs/docs/getting-started/running-containers.md
@@ -31,6 +31,11 @@ for instructions.
     finch run `
         public.ecr.aws/finch/hello-finch:latest
     ```
+=== "Linux"
+    ```shell
+    sudo finch run \
+        public.ecr.aws/finch/hello-finch:latest
+    ```
 
 
 You should now see the ASCII art in your terminal.
@@ -81,6 +86,12 @@ exposed on to the same port.
         --publish 80:80 `
         public.ecr.aws/nginx/nginx
     ```
+=== "Linux"
+    ```shell
+    finch run \
+        --publish 80:80 \
+        public.ecr.aws/nginx/nginx
+    ```
 
 Now in a web browser, you should be able to
 navigate to `localhost` and access the running web server container.
@@ -105,11 +116,23 @@ Popular `finch run` flags which will help you get started include:
             --rm `
             public.ecr.aws/finch/hello-finch:latest
         ```
+    === "Linux"
+        ```bash
+        sudo finch run \
+            --rm \
+            public.ecr.aws/finch/hello-finch:latest
+        ```
 
       * Verify that all containers have been removed
-      ```bash
-        $ finch ps --all
-      ```
+
+        === "macOS/Windows"
+            ```shell
+            $ finch ps --all
+            ```
+        === "Linux"
+            ```shell
+            $ sudo finch ps --all
+            ```
 
 * Start an interactive session into a container with the tty `--tty` and the
   interactive `--interactive` flags. Assuming your container image has a shell
@@ -131,6 +154,14 @@ Popular `finch run` flags which will help you get started include:
             public.ecr.aws/docker/library/amazonlinux:latest `
             /bin/bash
         ```
+    === "Linux"
+        ```bash
+        sudo finch run \
+            --interactive \
+            --tty \
+            public.ecr.aws/docker/library/amazonlinux:latest \
+            /bin/bash
+        ```
 
 * Start a container as a background process with the `--detach` flag.
 
@@ -148,6 +179,14 @@ Popular `finch run` flags which will help you get started include:
             --publish 80:80 `
             public.ecr.aws/nginx/nginx
         ```
+    === "Linux"
+        ```bash
+        sudo finch run \
+            --detach \
+            --publish 80:80 \
+            public.ecr.aws/nginx/nginx
+        ```
+
 
 ## Next Steps
 

--- a/docs/docs/getting-started/running-containers.md
+++ b/docs/docs/getting-started/running-containers.md
@@ -88,7 +88,7 @@ exposed on to the same port.
     ```
 === "Linux"
     ```shell
-    finch run \
+    sudo finch run \
         --publish 80:80 \
         public.ecr.aws/nginx/nginx
     ```
@@ -128,6 +128,10 @@ Popular `finch run` flags which will help you get started include:
         === "macOS/Windows"
             ```shell
             $ finch ps --all
+            ```
+        === "Windows / PowerShell"
+            ```powershell
+            finch ps --all
             ```
         === "Linux"
             ```shell

--- a/docs/docs/managing-finch/linux/installation.md
+++ b/docs/docs/managing-finch/linux/installation.md
@@ -19,8 +19,6 @@ So long as the first number is greater than 4, Finch is supported. The next sect
 
 Finch is packaged in the standard Amazon Linux repositories. That means, installing Finch is as easy as installing any other Amazon Linux package:
 
-### AL2023
-
 === "AL2023"
 
     ```shell
@@ -34,7 +32,9 @@ Finch is packaged in the standard Amazon Linux repositories. That means, install
     $ sudo yum install runfinch-finch
     ```
 
-After running this command, you will have a `finch` program in your PATH, and you can navigate to the [Verifying Finch install](../../../getting-started/installation/#verify-the-finch-installation) page to proceed. Navigate to the [Optional Components](./optional-components.md) page to configure Finch optional components. 
+After running this command, you will have a `finch` program in your PATH, and you can navigate to the [Verifying Finch install](../../../getting-started/installation/#verify-the-finch-installation) page to proceed. Navigate to the [Optional Components](./optional-components.md) page to configure Finch optional components.
+
+Note that the all of the following Finch guides will use `sudo finch ...`. There is an [optional mechanism to avoid the use of sudo](./../optional-components/#running-finch-without-sudo), follow the link for more information.
 
 ## Generic
 
@@ -65,4 +65,6 @@ The goal of these steps is to setup your system to mimic the configuration found
    1. [buildkit](https://github.com/runfinch/finch/blob/main//contrib/packaging/rpm/finch-buildkit.service)
    1. [finch-daemon](https://github.com/runfinch/finch-daemon/blob/main/finch.service)
 
-After completing this setup, you will have a `finch` program in your PATH, and you can navigate to the [Verifying Finch install](../../../getting-started/installation/#verify-the-finch-installation) page to proceed. Navigate to the [Optional Components](./optional-components.md) page to configure Finch optional components. 
+After completing this setup, you will have a `finch` program in your PATH, and you can navigate to the [Verifying Finch install](../../../getting-started/installation/#verify-the-finch-installation) page to proceed. Navigate to the [Optional Components](./optional-components.md) page to configure Finch optional components.
+
+Note that the all of the following Finch guides will use `sudo finch ...`. There is an [optional mechanism to avoid the use of sudo](./../optional-components/#running-finch-without-sudo), follow the link for more information.

--- a/docs/docs/managing-finch/linux/optional-components.md
+++ b/docs/docs/managing-finch/linux/optional-components.md
@@ -66,3 +66,26 @@ The ECR Credential Helper is packaged in the standard Amazon Linux repositories.
 ### Configuration
 
 The ECR Credential Helper must also be configured for the root user's docker config, which can be found at `/root/.docker/config.json`. Follow the steps in [this guide](https://github.com/awslabs/amazon-ecr-credential-helper?tab=readme-ov-file#configuration) to configure the credential helper.
+
+## Running finch without `sudo`
+
+By default, Finch requires `sudo` to run, since the containerd and buildkit daemons require root access. In order to avoid the need for typing `sudo` before every finch command, you can run the following:
+
+    ```bash
+    # create a new group which will contain all users that can run finch without sudo
+    /usr/sbin/groupadd -r "finch"
+    # add your user to the group
+    /usr/sbin/usermod -a -G "finch" "${USER}"
+
+    # allow users to execute without using "sudo"
+    sudo chgrp "finch" /usr/local/bin/nerdctl
+    sudo chmod +s /usr/local/bin/nerdctl
+    sudo chgrp "finch" /usr/bin/finch
+    sudo chmod +s /usr/bin/finch
+    ```
+
+NOTE: this process does not remove the requirement for running the commands with root privileges, it simply
+sidesteps the need to type `sudo` every execution.
+Evaluate whether using `chmod +s` fits your security posture before using this configuration.
+
+Reference: https://github.com/containerd/nerdctl/blob/main/docs/faq.md#does-nerdctl-have-an-equivalent-of-sudo-usermod--ag-docker-user-


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
- Adds `sudo` to the Linux docs where appropriate
    - The commands are almost identical to macOS, but better to have slight duplication in the name of simplicity
- Adds a new optional mechanism for avoiding the use of `sudo` on Linux

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
