### PR TITLE
docs: clarify compose version requirement for dev container compatibi…

### DIFF
--- a/docs/docs/integrations/mac/devcontainers.md
+++ b/docs/docs/integrations/mac/devcontainers.md
@@ -36,10 +36,14 @@ Open the extension settings by navigating within the setting window or using the
 - Configure the "Docker Path" to: `<path>/<to>/finch`
 
 
-## Advanced Network Creation with Compose:
+## Working with Docker Compose Projects in Dev Containers:
 
 When using `docker compose`, set the `DOCKER_COMPOSE_VERSION` to a value `> 2.9.0`.
 - Set the system environment variable within `.zshrc` and `source .zshrc`
 
 - Use `export DOCKER_COMPOSE_VERSION=x.x.x` for the current session
 
+> ⚠️ **Note:** Finch only supports dash (`-`) as the project name separator.
+> However, Dev Container tooling relies on the separator determined by `docker compose version`.
+> If the version is below `2.9.0`, it defaults to using underscores (`_`), causing name mismatches
+> and container startup failures. To ensure compatibility, set the `DOCKER_COMPOSE_VERSION` to `>= 2.9.0`.

--- a/docs/docs/integrations/windows/devcontainers.md
+++ b/docs/docs/integrations/windows/devcontainers.md
@@ -40,7 +40,7 @@ Open the extension settings by navigating within the setting window or using the
 - Disable the "Mount Wayland Socker" option
 
 
-## Advanced Network Creation with Compose:
+## Working with Docker Compose Projects in Dev Containers:
 When using `docker compose`, set the `DOCKER_COMPOSE_VERSION` to a value `> 2.9.0`.
 
 - Using the Command Prompt: use `set DOCKER_COMPOSE_VERSION=x.x.x` for the current session
@@ -48,3 +48,8 @@ When using `docker compose`, set the `DOCKER_COMPOSE_VERSION` to a value `> 2.9.
 - Using the PowerShell: use `$env:DOCKER_COMPOSE_VERSION = "x.x.x"` for the current session
 
 - Set the environment variable within the System Properties::Advanced System Settings::Environment Variables
+
+> ⚠️ **Note:** Finch only supports dash (`-`) as the project name separator. 
+> However, Dev Container tooling relies on the separator determined by `docker compose version`. 
+> If the version is below `2.9.0`, it defaults to using underscores (`_`), causing name mismatches 
+> and container startup failures. To ensure compatibility, set the `DOCKER_COMPOSE_VERSION` to `>= 2.9.0`.


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/runfinch/finch/issues/1378

**Description of changes:**
Added explanation for setting DOCKER_COMPOSE_VERSION >= 2.9.0 to avoid project name mismatches in Dev Container environments and improved the sub-heading.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
