### PR TITLE
fix(ci): add write perms for docs workflow

### DIFF
--- a/.github/workflows/pull_latest_docs.yml
+++ b/.github/workflows/pull_latest_docs.yml
@@ -11,15 +11,13 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   sync:
     name: Sync docs
     if: ${{ github.repository == 'runfinch/finch-website' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read # this is required for actions/checkout
     steps:
       - name: Checkout main
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
Added wrong perms, we needed write permissions as it was the PR step that was failing. Seems we also have an extraneous permissions line when the top permissions apply for the whole file so removed that and just added it to the global perms for the workflow.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
