### PR TITLE
feat: add docs for vmnet config in finch.yaml

### DIFF
--- a/docs/docs/configuration-reference.md
+++ b/docs/docs/configuration-reference.md
@@ -82,3 +82,17 @@ Many of Finch's configuration options are currently macOS only, and this will be
   Specifically, Finch will convert the Docker invocation into compatible nerdctl commands and arguments when possible.
   This option is required for running DevContainers on Finch.
 
+- `vmnet` **(macOS only)**: Enables shared networking for the virtual machine,
+  allowing the VM to obtain a routable IP address on the host network. The
+  behavior depends on the `vmType`:
+
+    - **`vmType: qemu`**: Installs [socket_vmnet](https://github.com/lima-vm/socket_vmnet)
+      to provide a bridged network interface. `finch vm init` will require a one-time
+      `sudo` prompt to install the socket_vmnet binary to `/opt/finch/` and configure
+      sudoers. Subsequent VM starts do not require sudo.
+    - **`vmType: vz`**: Uses Apple's native vzNAT to provide VM networking with no
+      privilege escalation required.
+
+  When disabled or unset (the default), the VM uses user-mode networking (slirp
+  for qemu, or the default vz network stack). Default is `false`.
+


### PR DESCRIPTION
**Description of changes:**

Adds documentation for the new `vmnet` configuration option in the configuration reference. This option was introduced in https://github.com/runfinch/finch/pull/1749 to make socket_vmnet opt-in rather than force-installed. Previously, every `finch vm init` required sudo to install socket_vmnet regardless of whether shared networking was needed.

With this change:
- **`vmType: qemu`** users who need shared networking explicitly set `vmnet: true` (sudo required once)
- **`vmType: vz`** users who set `vmnet: true` get vzNAT networking automatically with no privilege escalation
- **Default (`vmnet` unset/false)**: No sudo prompt, no socket_vmnet (the majority use case)

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under the terms of the licenses outlined in the LICENSE-SUMMARY file.
